### PR TITLE
Only tries to show preview for plain/text and images.

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -67,6 +67,10 @@
 	background-size: 250px;
 	background-repeat: no-repeat;
 	background-position: center;
+
+	&.element-preview-icon {
+		background-size: 128px;
+	}
 }
 
 .element-name,

--- a/css/style.scss
+++ b/css/style.scss
@@ -16,6 +16,7 @@
 	background-color: #fff;
 	filter: drop-shadow(0 1px 2px $color-box-shadow);
 	border-radius: $border-radius;
+	overflow: hidden;
 	height: 320px;
 	width: 250px;
 	margin-bottom: 16px;

--- a/js/script.js
+++ b/js/script.js
@@ -13,13 +13,12 @@ var RandomDeclutter = RandomDeclutter || {};
 		_containerBefore: 4,
 		_containerCurrent: 1,
 		_containerAfter: 2,
-		_containerActive: 'div.active div.element-preview',
+		_containerActive: '.active .element-preview',
 		_previewSize: 500,
 
 		load: function() {
 			return this._loadList();
 		},
-
 		_loadList: function() {
 			var self = this;
 
@@ -31,11 +30,9 @@ var RandomDeclutter = RandomDeclutter || {};
 				})
 			);
 		},
-
                 _onPreviewLoad: function(url){
 			$(this._containerActive).attr('style', 'background-image:url(' + url + ')');
                 },
-
 		_loadPreview: function(index) {
 			var self = this;
 			var params = {
@@ -121,7 +118,7 @@ var RandomDeclutter = RandomDeclutter || {};
 			$(container + (this._containerAfter))
 				.addClass('active');
 
-			this._containerCurrent++
+			this._containerCurrent++;
 			this._containerBefore++;
 			this._containerAfter++;
 		}

--- a/js/script.js
+++ b/js/script.js
@@ -5,7 +5,6 @@ var RandomDeclutter = RandomDeclutter || {};
 
 	var Manager = function() {
 		this.filesClient = OC.Files.getClient();
-		this.previewSize = 500;
 	};
 
 	Manager.prototype = {
@@ -14,6 +13,8 @@ var RandomDeclutter = RandomDeclutter || {};
 		_containerBefore: 4,
 		_containerCurrent: 1,
 		_containerAfter: 2,
+		_containerActive: 'div.active div.element-preview',
+		_previewSize: 500,
 
 		load: function() {
 			return this._loadList();
@@ -32,15 +33,15 @@ var RandomDeclutter = RandomDeclutter || {};
 		},
 
                 _onPreviewLoad: function(url){
-                    $('.element-preview').attr('style', 'background-image:url(' + url + ')');
+			$(this._containerActive).attr('style', 'background-image:url(' + url + ')');
                 },
 
 		_loadPreview: function(index) {
 			var self = this;
 			var params = {
 				fileId: self._list[index].id,
-				x: self.previewSize,
-				y: self.previewSize,
+				x: this._previewSize,
+				y: this._previewSize,
 				forceIcon: 0
 			};
 
@@ -48,7 +49,7 @@ var RandomDeclutter = RandomDeclutter || {};
 			var iconImg = new Image();
 			const iconUrl = OC.MimeType.getIconUrl(self._list[index].mimetype);
 			iconImg.src = iconUrl;
-			$('.element-preview').attr('style', 'background-image:url(' + iconUrl + ')');
+			$(this._containerActive).attr('style', 'background-image:url(' + iconUrl + ')');
 
 			// Try to get the preview if it is an image or a text file
 			if(self._list[index].mimetype == 'image/jpeg' ||
@@ -64,7 +65,7 @@ var RandomDeclutter = RandomDeclutter || {};
 
 		nextElement: function() {
 			var index = this._currentIndex++;
-			this._loadPreview(index);
+			if(this._list[index]) this._loadPreview(index);
 			return this._list[index];
 		},
 
@@ -86,6 +87,8 @@ var RandomDeclutter = RandomDeclutter || {};
 		},
 
 		moveContainer: function(direction) {
+			const container = '.element-container-';
+
 			if(this._currentIndex == 0) {
 				return;
 			}
@@ -101,24 +104,24 @@ var RandomDeclutter = RandomDeclutter || {};
 			}
 
 			// Move card out in specified direction
-			$('.element-container-' + this._containerCurrent)
+			$(container + this._containerCurrent)
 				.removeClass('fadeIn active')
 				.addClass('bounceOut' + direction);
 
 			// Card on the bottom of the stack gets cleaned up
 			// Emptycontent is shown when stack is over
 			if(!(this._currentIndex >= (this._list.length-2))) {
-				$('.element-container-' + (this._containerBefore))
+				$(container + (this._containerBefore))
 					.removeClass('bounceOutRight bounceOutLeft')
 					.addClass('fadeIn')
 					.attr('style', 'z-index: -' + this._currentIndex);
 			}
 
 			// Next card set as active
-			$('.element-container-' + (this._containerAfter))
+			$(container + (this._containerAfter))
 				.addClass('active');
 
-			this._containerCurrent++;
+			this._containerCurrent++
 			this._containerBefore++;
 			this._containerAfter++;
 		}

--- a/js/script.js
+++ b/js/script.js
@@ -18,6 +18,7 @@ var RandomDeclutter = RandomDeclutter || {};
 		load: function() {
 			return this._loadList();
 		},
+
 		_loadList: function() {
 			var self = this;
 
@@ -29,6 +30,11 @@ var RandomDeclutter = RandomDeclutter || {};
 				})
 			);
 		},
+
+                _onPreviewLoad: function(url){
+                    $('.element-preview').attr('style', 'background-image:url(' + url + ')');
+                },
+
 		_loadPreview: function(index) {
 			var self = this;
 			var params = {
@@ -37,16 +43,23 @@ var RandomDeclutter = RandomDeclutter || {};
 				y: self.previewSize,
 				forceIcon: 0
 			};
-			var img = new Image();
-			var previewUrl = OC.generateUrl('/core/preview?') + $.param(params);
-			img.onload = function() {
-				$('.element-preview').attr('style', 'background-image:url(' + previewUrl + ')');
-			};
-			img.onerror = function(){
-				previewUrl = OC.MimeType.getIconUrl(self._list[index].mimetype);
-				$('.element-preview').attr('style', 'background-image:url(' + previewUrl + ')');
-			};
-			img.src = previewUrl;
+
+			// Default
+			var iconImg = new Image();
+			const iconUrl = OC.MimeType.getIconUrl(self._list[index].mimetype);
+			iconImg.src = iconUrl;
+			$('.element-preview').attr('style', 'background-image:url(' + iconUrl + ')');
+
+			// Try to get the preview if it is an image or a text file
+			if(self._list[index].mimetype == 'image/jpeg' ||
+				self._list[index].mimetype == 'image/png' ||
+				self._list[index].mimetype == 'image/gif' ||
+				self._list[index].mimetype == 'text/plain'){
+				var previewImg = new Image();
+				const previewUrl = OC.generateUrl('/core/preview?') + $.param(params);
+				previewImg.onload = self._onPreviewLoad(previewUrl);
+				previewImg.src = previewUrl;
+			}
 		},
 
 		nextElement: function() {


### PR DESCRIPTION
Exactly what the title says :)
I was trying to catch the 404 error when it doesn't have a preview but it is impossible because the error is actually thrown by core. So I believe the best solution is to only display the known previews otherwise falls back to the icon.