### PR TITLE
Restored compatibility with Nextcloud 32 (backend + frontend fixes)

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -1,177 +1,219 @@
 var KeepOrSweep = KeepOrSweep || {};
 
-(function(window, OC, exports, undefined) {
-	'use strict';
+(function (window, OC, exports, undefined) {
+    'use strict';
 
-	var Manager = function() {
-		this.filesClient = OC.Files.getClient();
-	};
+    var Manager = function () {
+        this.filesClient = OC.Files.getClient();
 
-	Manager.prototype = {
+        // IMPORTANT: initialize list
+        this._list = [];
+    };
 
-		_currentIndex: 0,
-		_containerBefore: 4,
-		_containerCurrent: 1,
-		_containerAfter: 2,
-		_containerActive: '.active .element-preview',
-		_previewSize: 500,
+    Manager.prototype = {
 
-		load: function() {
-			return this._loadList();
-		},
-		_loadList: function() {
-			var self = this;
+        _currentIndex: 0,
+        _containerBefore: 4,
+        _containerCurrent: 1,
+        _containerAfter: 2,
+        _containerActive: '.active .element-preview',
+        _previewSize: 500,
 
-			var baseUrl = OC.generateUrl('/apps/keeporsweep');
-			return (
-				$.getJSON(baseUrl + '/files')
-				.then(function(result) {
-					self._list = _.shuffle(result);
-				})
-			);
-		},
-                _onPreviewLoad: function(url){
-			$(this._containerActive).attr('style', 'background-image:url("' + url + '")');
-                },
-		_loadPreview: function(index) {
-			var self = this;
-			var params = {
-				file: self._list[index].path + self._list[index].name,
-				fileId: self._list[index].id,
-				x: this._previewSize,
-				y: this._previewSize,
-				forceIcon: 0
-			};
+        load: function () {
+            return this._loadList();
+        },
 
-			// Default
-			var iconImg = new Image();
-			const iconUrl = OC.MimeType.getIconUrl(self._list[index].mimetype);
-			iconImg.src = iconUrl;
-			$(this._containerActive).attr('style', 'background-image:url("' + iconUrl + '")');
+        _loadList: function () {
+            var self = this;
 
-			// Try to get the preview if it is an image or a text file
-			if(self._list[index].mimetype == 'image/jpeg' ||
-				self._list[index].mimetype == 'image/png' ||
-				self._list[index].mimetype == 'image/gif' ||
-				self._list[index].mimetype == 'text/plain'){
-				var previewImg = new Image();
-				const previewUrl = OC.generateUrl('/core/preview.png?') + $.param(params);
-				previewImg.onload = self._onPreviewLoad(previewUrl);
-				previewImg.src = previewUrl;
-			}
-		},
+            var baseUrl = OC.generateUrl('/apps/keeporsweep');
+            return $.getJSON(baseUrl + '/files')
+                .then(function (result) {
+                    if (!Array.isArray(result)) {
+                        console.error('KeepOrSweep: expected array from /files, got', result);
+                        self._list = [];
+                        self._currentIndex = 0;
+                        return;
+                    }
 
-		nextElement: function() {
-			var index = this._currentIndex++;
-			if(this._list[index]) this._loadPreview(index);
-			return this._list[index];
-		},
+                    // Avoid depending on underscore (_.shuffle)
+                    self._list = result.slice().sort(function () {
+                        return Math.random() - 0.5;
+                    });
+                    self._currentIndex = 0;
+                })
+                .catch(function (err) {
+                    console.error('KeepOrSweep: failed to load list', err);
+                    self._list = [];
+                    self._currentIndex = 0;
+                });
+        },
 
-		keepElement: function() {
-			if (this._currentIndex > this._list.length) {
-				return;
-			}
+        _onPreviewLoad: function (url) {
+            $(this._containerActive).attr('style', 'background-image:url("' + url + '")');
+        },
 
-			this.moveContainer('Right');
-		},
+        _loadPreview: function (index) {
+            var self = this;
 
-		sweepElement: function(path) {
-			if (this._currentIndex > this._list.length) {
-				return;
-			}
+            if (!Array.isArray(self._list) || !self._list[index]) {
+                return;
+            }
 
-			this.moveContainer('Left');
-			this.filesClient.remove(path);
-		},
+            var file = self._list[index];
 
-		moveContainer: function(direction) {
-			const container = '.element-container-';
+            var params = {
+                file: file.path + file.name,
+                fileId: file.id,
+                x: this._previewSize,
+                y: this._previewSize,
+                forceIcon: 0
+            };
 
-			if(this._currentIndex == 0) {
-				return;
-			}
+            // Default icon
+            var iconUrl = OC.MimeType.getIconUrl(file.mimetype);
+            $(this._containerActive).attr('style', 'background-image:url("' + iconUrl + '")');
 
-			if(this._containerCurrent > 4) {
-				this._containerCurrent = 1;
-			}
-			if(this._containerBefore > 4) {
-				this._containerBefore = 1;
-			}
-			if(this._containerAfter > 4) {
-				this._containerAfter = 1;
-			}
+            // Try to get the preview if it is an image or a text file
+            if (
+                file.mimetype === 'image/jpeg' ||
+                file.mimetype === 'image/png' ||
+                file.mimetype === 'image/gif' ||
+                file.mimetype === 'text/plain'
+            ) {
+                var previewImg = new Image();
+                const previewUrl = OC.generateUrl('/core/preview.png?') + $.param(params);
 
-			// Move card out in specified direction
-			$(container + this._containerCurrent)
-				.removeClass('fadeIn active')
-				.addClass('bounceOut' + direction);
+                previewImg.onload = function () {
+                    self._onPreviewLoad(previewUrl);
+                };
 
-			// Card on the bottom of the stack gets cleaned up
-			// Emptycontent is shown when stack is over
-			if(!(this._currentIndex >= (this._list.length-2))) {
-				$(container + (this._containerBefore))
-					.removeClass('bounceOutRight bounceOutLeft')
-					.addClass('fadeIn')
-					.attr('style', 'z-index: -' + this._currentIndex);
-			}
+                previewImg.src = previewUrl;
+            }
+        },
 
-			// Next card set as active
-			$(container + (this._containerAfter))
-				.addClass('active');
+        nextElement: function () {
+            if (!Array.isArray(this._list) || this._list.length === 0) {
+                return null;
+            }
 
-			this._containerCurrent++;
-			this._containerBefore++;
-			this._containerAfter++;
-		}
-	}
+            if (this._currentIndex >= this._list.length) {
+                return null;
+            }
 
-	var manager = new Manager();
+            var index = this._currentIndex++;
+            this._loadPreview(index);
+            return this._list[index];
+        },
 
-	var app = new Vue({
-		el: '#app-content',
-		container: '#app-content .element-container',
-		data: {
-			file: {},
-			actionKeepHover: false,
-			actionSweepHover: false
-		},
-		methods: {
-			next: function() {
-				var file = manager.nextElement();
-				if(file) {
-					this.file = file;
-				}
-			},
-			keep: function() {
-				manager.keepElement();
-				this.next();
-			},
-			sweep: function() {
-				var path = this.file.path + this.file.name;
-				manager.sweepElement(path);
-				this.next();
-			},
-			// Keyboard shortcuts thanks to https://vuejsdevelopers.com/2017/05/01/vue-js-cant-help-head-body/
-			keyListener: function(evt) {
-				// Keep: Space, →, Enter
-				if(evt.keyCode === 32 || evt.keyCode === 39 || evt.keyCode === 13) {
-					this.keep();
-				}
-				// Sweep: Delete, ←
-				if(evt.keyCode === 46 || evt.keyCode === 37) {
-					this.sweep();
-				}
-			}
-		},
-		created: function() {
-			document.addEventListener('keyup', this.keyListener);
-		},
-		destroyed: function() {
-			document.removeEventListener('keyup', this.keyListener);
-		}
-	});
+        keepElement: function () {
+            if (!Array.isArray(this._list) || this._currentIndex >= this._list.length) {
+                return;
+            }
 
-	manager.load()
-	.then(app.next);
+            this.moveContainer('Right');
+        },
+
+        sweepElement: function (path) {
+            if (!Array.isArray(this._list) || this._currentIndex >= this._list.length) {
+                return;
+            }
+
+            this.moveContainer('Left');
+            this.filesClient.remove(path);
+        },
+
+        moveContainer: function (direction) {
+            const container = '.element-container-';
+
+            if (!Array.isArray(this._list) || this._list.length === 0) {
+                return;
+            }
+
+            if (this._currentIndex === 0) {
+                return;
+            }
+
+            if (this._containerCurrent > 4) {
+                this._containerCurrent = 1;
+            }
+            if (this._containerBefore > 4) {
+                this._containerBefore = 1;
+            }
+            if (this._containerAfter > 4) {
+                this._containerAfter = 1;
+            }
+
+            // Move card out in specified direction
+            $(container + this._containerCurrent)
+                .removeClass('fadeIn active')
+                .addClass('bounceOut' + direction);
+
+            // Card on the bottom of the stack gets cleaned up
+            // Empty content is shown when stack is over
+            if (!(this._currentIndex >= (this._list.length - 2))) {
+                $(container + (this._containerBefore))
+                    .removeClass('bounceOutRight bounceOutLeft')
+                    .addClass('fadeIn')
+                    .attr('style', 'z-index: -' + this._currentIndex);
+            }
+
+            // Next card set as active
+            $(container + (this._containerAfter))
+                .addClass('active');
+
+            this._containerCurrent++;
+            this._containerBefore++;
+            this._containerAfter++;
+        }
+    };
+
+    var manager = new Manager();
+
+    var app = new Vue({
+        el: '#app-content',
+        container: '#app-content .element-container',
+        data: {
+            file: {},
+            actionKeepHover: false,
+            actionSweepHover: false
+        },
+        methods: {
+            next: function () {
+                var file = manager.nextElement();
+                if (file) {
+                    this.file = file;
+                }
+            },
+            keep: function () {
+                manager.keepElement();
+                this.next();
+            },
+            sweep: function () {
+                var path = this.file.path + this.file.name;
+                manager.sweepElement(path);
+                this.next();
+            },
+            // Keyboard shortcuts thanks to https://vuejsdevelopers.com/2017/05/01/vue-js-cant-help-head-body/
+            keyListener: function (evt) {
+                // Keep: Space, →, Enter
+                if (evt.keyCode === 32 || evt.keyCode === 39 || evt.keyCode === 13) {
+                    this.keep();
+                }
+                // Sweep: Delete, ←
+                if (evt.keyCode === 46 || evt.keyCode === 37) {
+                    this.sweep();
+                }
+            }
+        },
+        created: function () {
+            document.addEventListener('keyup', this.keyListener);
+        },
+        destroyed: function () {
+            document.removeEventListener('keyup', this.keyListener);
+        }
+    });
+
+    manager.load().then(app.next);
 
 })(window, OC, KeepOrSweep);

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -12,7 +12,7 @@ class ApiController extends Controller {
 	private IRootFolder $rootFolder;
 	private ?string $userId;
 
-	public function  __construct($appName, IRequest $request, IRootFolder $rootFolder, ?string $userId = null) {
+	public function __construct($appName, IRequest $request, IRootFolder $rootFolder, ?string $userId = null) {
 		parent::__construct($appName, $request);
 		$this->rootFolder = $rootFolder;
 		$this->userId = $userId;
@@ -21,21 +21,47 @@ class ApiController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	public function files() {
-		$files = $this->getFilesRecursive();
-		$results = \OCA\Files\Helper::formatFileInfos($files);
-		foreach ($results as $key => $result) {
-			$path = $this->getRelativePath($files[$key]->getPath());
-			$results[$key]['path'] = $path;
+	public function files(): DataResponse {
+		// Collect all files for the current user
+		$fileInfos = $this->getFilesRecursive();
+
+		// Manually format file info instead of using the removed
+		// \OCA\Files\Helper::formatFileInfos()
+		$results = [];
+		foreach ($fileInfos as $fileInfo) {
+			// Basic fields that the frontend actually uses
+			$entry = [
+				'id'       => $fileInfo->getId(),
+				'name'     => $fileInfo->getName(),
+				'mimetype' => $fileInfo->getMimetype(),
+				'mtime'    => $fileInfo->getMTime() * 1000, // ms, similar to core helper
+				'size'     => $fileInfo->getSize(),
+				'type'     => $fileInfo->getType(),
+			];
+
+			// Add relative path (directory only, no filename)
+			$path = $this->getRelativePath($fileInfo->getPath());
+			$entry['path'] = $path;
+
+			$results[] = $entry;
 		}
 
 		return new DataResponse($results);
 	}
 
-	private function getFilesRecursive(& $results = [], $path = '') {
+	/**
+	 * Recursively collect FileInfo objects under the given path.
+	 *
+	 * @param array $results
+	 * @param string $path
+	 * @return array
+	 */
+	private function getFilesRecursive(array &$results = [], string $path = ''): array {
 		$userFolder = $this->rootFolder->getUserFolder($this->userId);
-		$files = $userFolder->get($path)->getDirectoryListing();
-		foreach($files as $file) {
+		$dirNode = $userFolder->get($path);
+		$files = $dirNode->getDirectoryListing();
+
+		foreach ($files as $file) {
 			if ($file->getType() === 'dir') {
 				$this->getFilesRecursive($results, $path . '/' . $file->getName());
 			} else {
@@ -46,9 +72,16 @@ class ApiController extends Controller {
 		return $results;
 	}
 
-	private function getRelativePath($path) {
-		$path = Filesystem::getView()->getRelativePath($path);
-		return substr($path, 0, strlen($path) - strlen(basename($path)));
+	/**
+	 * Convert an absolute path to a path relative to the user view,
+	 * then strip the filename so we only keep the directory portion.
+	 *
+	 * @param string $path
+	 * @return string
+	 */
+	private function getRelativePath(string $path): string {
+		$relative = Filesystem::getView()->getRelativePath($path);
+		// remove the basename (file name) from the path, keep trailing slash semantics
+		return substr($relative, 0, strlen($relative) - strlen(basename($relative)));
 	}
-
 }


### PR DESCRIPTION
PR restores functionality on Nextcloud 32.
Two issues are resolved:

1. **Backend 500 error**

   * `OCA\Files\Helper::formatFileInfos()` was removed in recent NC versions.
   * Replaced with a lightweight formatter built around core `FileInfo` fields.
   * Fixes `/apps/keeporsweep/files` endpoint and prevents server-side fatal errors.

2. **Frontend runtime errors**

   * `_list` was uninitialized, causing `undefined.length` crashes when clicking Keep/Sweep.
   * Removed dependency on `_.shuffle`, which was not available.
   * Corrected preview `onload` logic, improved safety around file iteration, and added guards.

No feature or UX changes — just functional restoration.